### PR TITLE
bump up dashboard ui version

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -22,7 +22,7 @@ RUN wget -O - ${!DOCKER_URL} > /usr/bin/docker && chmod +x /usr/bin/docker
 ENV GIT_COMMIT="327be56d3a6a2b85cf4751148f6834402e8211d5" \
     GIT_BRANCH="kube-explorer" \
     GIT_SOURCE="/go/src/github.com/rancher/steve" \
-    CATTLE_DASHBOARD_UI_VERSION=v2.5.8
+    CATTLE_DASHBOARD_UI_VERSION=v2.5.8-cn
 
 ENV DAPPER_ENV REPO TAG DRONE_TAG CROSS
 ENV DAPPER_SOURCE /opt/kube-explorer

--- a/scripts/download
+++ b/scripts/download
@@ -10,7 +10,7 @@ git reset --hard ${GIT_COMMIT}
 
 mkdir -p pkg/ui/ui/dashboard
 cd pkg/ui/ui/dashboard
-curl -sL https://releases.rancher.com/dashboard/${CATTLE_DASHBOARD_UI_VERSION}.tar.gz | tar xvzf - --strip-components=2
+curl -sL https://rancher-dashboard-ui.s3.ap-southeast-2.amazonaws.com/release-2.5/${CATTLE_DASHBOARD_UI_VERSION}.tar.gz | tar xvzf - --strip-components=2
 cp index.html ../index.html
 
 popd


### PR DESCRIPTION
- Change static resource path to relative path.
- Change dashboard UI router path from absolute `/dashboard/` path to splicing `/dashboard/` with base tag href value.
- Change dashboard API or WebSocket request path from absolute `/v1` or `/k8s` to splicing `/v1` or `/k8s` with base tag href value.